### PR TITLE
fix: 4.7 alignment 坐标转换

### DIFF
--- a/src/chapter4/alignment.md
+++ b/src/chapter4/alignment.md
@@ -78,7 +78,8 @@ Alignment(this.x, this.y)
 `Alignment`可以通过其**坐标转换公式**将其坐标转为子元素的具体偏移坐标：
 
 ```
-(Alignment.x*childWidth/2+childWidth/2, Alignment.y*childHeight/2+childHeight/2)
+实际偏移 = (Alignment.x * (parentWidth - childWidth) / 2 + (parentWidth - childWidth) / 2,
+        Alignment.y * (parentHeight - childHeight) / 2 + (parentHeight - childHeight) / 2)
 ```
 
 其中`childWidth`为子元素的宽度，`childHeight`为子元素高度。
@@ -105,7 +106,7 @@ Alignment(this.x, this.y)
 `FractionalOffset` 继承自 `Alignment `，它和 `Alignment `唯一的区别就是坐标原点不同！`FractionalOffset` 的坐标原点为矩形的左侧顶点，这和布局系统的一致，所以理解起来会比较容易。`FractionalOffset`的坐标转换公式为：
 
 ```
-实际偏移 = (FractionalOffse.x * childWidth, FractionalOffse.y * childHeight)
+实际偏移 = (FractionalOffse.x * (parentWidth - childWidth), FractionalOffse.y * (parentHeight - childHeight))
 ```
 
 下面看一个例子：


### PR DESCRIPTION
# Chapter 4.7 坐标转换公式有误

[https://api.flutter-io.cn/flutter/widgets/Align-class.html](https://api.flutter-io.cn/flutter/widgets/Align-class.html)

## FractionalOffset

> The [FractionalOffset](https://api.flutter-io.cn/flutter/painting/FractionalOffset-class.html) used in the following example defines two points:
>
> - (0.2 * width of [FlutterLogo](https://api.flutter-io.cn/flutter/material/FlutterLogo-class.html), 0.6 * height of [FlutterLogo](https://api.flutter-io.cn/flutter/material/FlutterLogo-class.html)) = (12.0, 36.0) in the coordinate system of the blue container.
> - (0.2 * width of [Align](https://api.flutter-io.cn/flutter/widgets/Align-class.html), 0.6 * height of [Align](https://api.flutter-io.cn/flutter/widgets/Align-class.html)) = (24.0, 72.0) in the coordinate system of the [Align](https://api.flutter-io.cn/flutter/widgets/Align-class.html) widget.
>
> The [Align](https://api.flutter-io.cn/flutter/widgets/Align-class.html) widget positions the [FlutterLogo](https://api.flutter-io.cn/flutter/material/FlutterLogo-class.html) such that the two points are on top of each other. In this example, the top left of the [FlutterLogo](https://api.flutter-io.cn/flutter/material/FlutterLogo-class.html) will be placed at (24.0, 72.0) - (12.0, 36.0) = (12.0, 36.0) from the top left of the [Align](https://api.flutter-io.cn/flutter/widgets/Align-class.html) widget.

根据官方文档可知公式为:

```
x = FractionalOffse.x * parentWidth - FractionalOffse.x * childWidth
y = FractionalOffse.y * parentHeight - FractionalOffse.y * chilHeight
```

## Alignment

> The [Alignment](https://api.flutter-io.cn/flutter/painting/Alignment-class.html) used in the following example defines a single point:
>
> - (0.2 * width of [FlutterLogo](https://api.flutter-io.cn/flutter/material/FlutterLogo-class.html)/2 + width of [FlutterLogo](https://api.flutter-io.cn/flutter/material/FlutterLogo-class.html)/2, 0.6 * height of [FlutterLogo](https://api.flutter-io.cn/flutter/material/FlutterLogo-class.html)/2 + height of [FlutterLogo](https://api.flutter-io.cn/flutter/material/FlutterLogo-class.html)/2) = (36.0, 48.0).

官方文档好像也有错误，我经过测试得出的结论为：实际的坐标也需要根据父组件计算
公式为:

```
x = Alignment.x * (parentWidth - childWidth) / 2 + (parentWidth - childWidth) / 2
y = Alignment.y * (parentHeight - childHeight) / 2 + (parentHeight - childHeight) / 2
```

## 测试环境

```
Flutter 3.0.5 • channel stable • https://github.com/flutter/flutter.git
Framework • revision f1875d570e (4 weeks ago) • 2022-07-13 11:24:16 -0700
Engine • revision e85ea0e79c
Tools • Dart 2.17.6 • DevTools 2.12.2
```

