### PR TITLE
Modify the "3. Cupertino component" code error

### DIFF
--- a/src/chapter2/flutter_widget_intro.md
+++ b/src/chapter2/flutter_widget_intro.md
@@ -574,16 +574,18 @@ Flutter 也提供了一套丰富的 Cupertino 风格的组件，尽管目前还�
 import 'package:flutter/cupertino.dart';
 
 class CupertinoTestRoute extends StatelessWidget  {
+  const CupertinoTestRoute({Key? key}) : super(key: key);
+
   @override
-  widget build(BuildContext context) {
+  Widget build(BuildContext context) {
     return CupertinoPageScaffold(
-      navigationBar: CupertinoNavigationBar(
+      navigationBar: const CupertinoNavigationBar(
         middle: Text("Cupertino Demo"),
       ),
       child: Center(
         child: CupertinoButton(
             color: CupertinoColors.activeBlue,
-            child: Text("Press"),
+            child: const Text("Press"),
             onPressed: () {}
         ),
       ),


### PR DESCRIPTION
1. Widget words are not capitalized
2. Use key in widget constructors.
3. Prefer const with constant constructors.